### PR TITLE
Add markdown render endpoint with docs

### DIFF
--- a/KANBAN.md
+++ b/KANBAN.md
@@ -2,12 +2,15 @@
 
 ## Backlog
 - Landing Page gestalten
-- REST-API Grundgerüst aufsetzen
 - DevContainer für VS Code konfigurieren
 - Docker Compose zum Starten aller Services erstellen
+- File Upload Endpoint implementieren
 
 ## In Progress
-- README erweitern und Dokumentation verbessern
+- API Tests erweitern
 
 ## Done
 - Repository initialisiert
+- REST-API Grundgerüst aufgesetzt
+- README erweitert und Dokumentation verbessert
+- Markdown-Renderer Endpoint umgesetzt

--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ Dieses Repository dient als Testumgebung für:
 - [ ] Lokale Sprachumschaltung (Deutsch/Englisch)
 
 ### ⚙️ Backend-Entwicklung
-- [ ] REST-API mit einfachen Endpunkten (`/api/ping`, `/api/info`)
+- [x] REST-API mit einfachen Endpunkten (`/api/ping`, `/api/info`)
 - [ ] File Upload + File Serving über die API
 - [ ] Einfacher JSON-Datenspeicher (Dateibasiert)
 - [ ] Dummy-Login mit Session (Cookie oder Token-basiert)
-- [ ] Serverseitiger Markdown-Renderer
+- [x] Serverseitiger Markdown-Renderer
 
 ### 🎲 Interaktive Spiele (Frontend/Backend kombiniert)
 - [ ] Einfaches Schachspiel mit KI oder Zwei-Spieler-Logik
@@ -78,6 +78,10 @@ python api/app.py
 ```
 
 Die Endpunkte sind anschließend unter `http://localhost:5000/api/*` verfügbar.
+
+### Neue Endpunkte
+
+- `POST /api/render` – erwartet JSON `{"text": "# Titel"}` und liefert gerendetes HTML zurück
 
 ## 🖥️ Lokale Nutzung
 

--- a/api/app.py
+++ b/api/app.py
@@ -1,4 +1,5 @@
-from flask import Flask, jsonify
+from flask import Flask, jsonify, request
+import markdown
 
 app = Flask(__name__)
 
@@ -9,6 +10,15 @@ def ping():
 @app.route('/api/info')
 def info():
     return jsonify({'project': 'Codex Playground', 'status': 'development'})
+
+@app.route('/api/render', methods=['POST'])
+def render_markdown():
+    data = request.get_json() or {}
+    text = data.get('text')
+    if not text:
+        return jsonify({'error': 'no text provided'}), 400
+    html = markdown.markdown(text)
+    return jsonify({'html': html})
 
 if __name__ == '__main__':
     app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 Flask>=2.3
+markdown>=3.4

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -5,3 +5,20 @@ def test_ping():
     res = client.get('/api/ping')
     assert res.status_code == 200
     assert res.get_json() == {'message': 'pong'}
+
+def test_info():
+    client = app.test_client()
+    res = client.get('/api/info')
+    assert res.status_code == 200
+    assert res.get_json() == {'project': 'Codex Playground', 'status': 'development'}
+
+def test_render_markdown():
+    client = app.test_client()
+    res = client.post('/api/render', json={'text': '# Title'})
+    assert res.status_code == 200
+    assert res.get_json() == {'html': '<h1>Title</h1>'}
+
+def test_render_markdown_no_text():
+    client = app.test_client()
+    res = client.post('/api/render', json={})
+    assert res.status_code == 400


### PR DESCRIPTION
## Summary
- add server-side markdown rendering endpoint
- expand API tests
- document new endpoint in README
- update Kanban board
- add markdown to requirements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'api')*

------
https://chatgpt.com/codex/tasks/task_e_685d3df172f0832493e80dcd2e661e2a