### PR TITLE
Implement file upload and serving

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -1,7 +1,24 @@
-from flask import Flask, jsonify, request
+import os
+from pathlib import Path
+
+from flask import Flask, jsonify, request, send_from_directory
+from werkzeug.utils import secure_filename
 import markdown
 
+BASE_DIR = Path(__file__).resolve().parent.parent
+UPLOAD_FOLDER = BASE_DIR / "uploads"
+UPLOAD_FOLDER.mkdir(exist_ok=True)
+
 app = Flask(__name__)
+app.config["UPLOAD_FOLDER"] = str(UPLOAD_FOLDER)
+app.config["MAX_CONTENT_LENGTH"] = 1 * 1024 * 1024  # 1MB
+
+ALLOWED_EXTENSIONS = {"txt", "png", "jpg", "jpeg", "gif"}
+
+
+def allowed_file(filename: str) -> bool:
+    """Check if the filename has an allowed extension."""
+    return "." in filename and filename.rsplit(".", 1)[1].lower() in ALLOWED_EXTENSIONS
 
 @app.route('/api/ping')
 def ping():
@@ -19,6 +36,34 @@ def render_markdown():
         return jsonify({'error': 'no text provided'}), 400
     html = markdown.markdown(text)
     return jsonify({'html': html})
+
+
+@app.route('/api/upload', methods=['POST'])
+def upload_file():
+    """Handle file uploads with basic validation."""
+    if 'file' not in request.files:
+        return jsonify({'error': 'no file part'}), 400
+
+    file = request.files['file']
+
+    if file.filename == '':
+        return jsonify({'error': 'no selected file'}), 400
+
+    filename = secure_filename(file.filename)
+
+    if not allowed_file(filename):
+        return jsonify({'error': 'invalid file type'}), 400
+
+    save_path = Path(app.config['UPLOAD_FOLDER']) / filename
+    file.save(save_path)
+    return jsonify({'filename': filename}), 201
+
+
+@app.route('/api/files/<path:filename>')
+def get_file(filename):
+    """Serve a file from the upload directory."""
+    safe_name = secure_filename(filename)
+    return send_from_directory(app.config['UPLOAD_FOLDER'], safe_name)
 
 if __name__ == '__main__':
     app.run(debug=True)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,4 +1,6 @@
 from api.app import app
+import io
+import os
 
 def test_ping():
     client = app.test_client()
@@ -22,3 +24,26 @@ def test_render_markdown_no_text():
     client = app.test_client()
     res = client.post('/api/render', json={})
     assert res.status_code == 400
+
+
+def test_file_upload_and_download(tmp_path):
+    app.config['UPLOAD_FOLDER'] = str(tmp_path)
+    client = app.test_client()
+    data = {'file': (io.BytesIO(b'hello'), 'hello.txt')}
+    res = client.post('/api/upload', data=data, content_type='multipart/form-data')
+    assert res.status_code == 201
+    assert res.get_json() == {'filename': 'hello.txt'}
+    assert (tmp_path / 'hello.txt').exists()
+
+    res = client.get('/api/files/hello.txt')
+    assert res.status_code == 200
+    assert res.data == b'hello'
+
+
+def test_upload_invalid_type(tmp_path):
+    app.config['UPLOAD_FOLDER'] = str(tmp_path)
+    client = app.test_client()
+    data = {'file': (io.BytesIO(b'bad'), 'bad.exe')}
+    res = client.post('/api/upload', data=data, content_type='multipart/form-data')
+    assert res.status_code == 400
+


### PR DESCRIPTION
## Summary
- add upload folder configuration and validation helpers
- implement `/api/upload` endpoint to accept and store files securely
- implement `/api/files/<filename>` endpoint to serve stored files
- add tests for uploading and downloading files

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed: 403 Forbidden)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685d3fa5eb7883249443b894022b7e76