### PR TITLE
Implement JSON store and CRUD API

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Dieses Repository dient als Testumgebung für:
 ### ⚙️ Backend-Entwicklung
 - [x] REST-API mit einfachen Endpunkten (`/api/ping`, `/api/info`)
 - [ ] File Upload + File Serving über die API
-- [ ] Einfacher JSON-Datenspeicher (Dateibasiert)
+ - [x] Einfacher JSON-Datenspeicher (Dateibasiert)
 - [ ] Dummy-Login mit Session (Cookie oder Token-basiert)
 - [x] Serverseitiger Markdown-Renderer
 

--- a/api/app.py
+++ b/api/app.py
@@ -1,5 +1,6 @@
 from flask import Flask, jsonify, request
 import markdown
+from data import store
 
 app = Flask(__name__)
 
@@ -19,6 +20,47 @@ def render_markdown():
         return jsonify({'error': 'no text provided'}), 400
     html = markdown.markdown(text)
     return jsonify({'html': html})
+
+
+# Simple JSON store endpoints
+@app.route('/api/store', methods=['GET'])
+def list_entries():
+    return jsonify(store.read_all())
+
+
+@app.route('/api/store/<int:entry_id>', methods=['GET'])
+def get_single_entry(entry_id):
+    entry = store.get_entry(entry_id)
+    if entry is None:
+        return jsonify({'error': 'not found'}), 404
+    return jsonify(entry)
+
+
+@app.route('/api/store', methods=['POST'])
+def create_entry():
+    data = request.get_json() or {}
+    if not isinstance(data, dict):
+        return jsonify({'error': 'invalid data'}), 400
+    new_entry = store.add_entry(data)
+    return jsonify(new_entry), 201
+
+
+@app.route('/api/store/<int:entry_id>', methods=['PUT'])
+def update_single_entry(entry_id):
+    data = request.get_json() or {}
+    if not isinstance(data, dict):
+        return jsonify({'error': 'invalid data'}), 400
+    updated = store.update_entry(entry_id, data)
+    if updated is None:
+        return jsonify({'error': 'not found'}), 404
+    return jsonify(updated)
+
+
+@app.route('/api/store/<int:entry_id>', methods=['DELETE'])
+def delete_single_entry(entry_id):
+    if store.delete_entry(entry_id):
+        return jsonify({'status': 'deleted'})
+    return jsonify({'error': 'not found'}), 404
 
 if __name__ == '__main__':
     app.run(debug=True)

--- a/data/store.py
+++ b/data/store.py
@@ -1,0 +1,71 @@
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+from filelock import FileLock
+
+DATA_DIR = Path(__file__).resolve().parent
+DATA_FILE = DATA_DIR / "store.json"
+LOCK_FILE = DATA_FILE.with_suffix(".lock")
+
+# ensure directory exists
+DATA_DIR.mkdir(parents=True, exist_ok=True)
+
+lock = FileLock(str(LOCK_FILE))
+
+
+def _load_data() -> List[Dict[str, Any]]:
+    with lock:
+        if DATA_FILE.exists():
+            with DATA_FILE.open("r", encoding="utf-8") as f:
+                try:
+                    return json.load(f)
+                except json.JSONDecodeError:
+                    return []
+        return []
+
+
+def _save_data(data: List[Dict[str, Any]]) -> None:
+    with lock:
+        with DATA_FILE.open("w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2)
+
+
+def read_all() -> List[Dict[str, Any]]:
+    return _load_data()
+
+
+def get_entry(entry_id: int) -> Optional[Dict[str, Any]]:
+    data = _load_data()
+    for entry in data:
+        if entry.get("id") == entry_id:
+            return entry
+    return None
+
+
+def add_entry(entry: Dict[str, Any]) -> Dict[str, Any]:
+    data = _load_data()
+    next_id = max((item.get("id", 0) for item in data), default=0) + 1
+    entry_with_id = {"id": next_id, **entry}
+    data.append(entry_with_id)
+    _save_data(data)
+    return entry_with_id
+
+
+def update_entry(entry_id: int, entry: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    data = _load_data()
+    for idx, item in enumerate(data):
+        if item.get("id") == entry_id:
+            data[idx] = {"id": entry_id, **entry}
+            _save_data(data)
+            return data[idx]
+    return None
+
+
+def delete_entry(entry_id: int) -> bool:
+    data = _load_data()
+    for idx, item in enumerate(data):
+        if item.get("id") == entry_id:
+            data.pop(idx)
+            _save_data(data)
+            return True
+    return False

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Flask>=2.3
 markdown>=3.4
+filelock>=3.12

--- a/tests/test_store_api.py
+++ b/tests/test_store_api.py
@@ -1,0 +1,48 @@
+import json
+from api.app import app
+from data import store
+from filelock import FileLock
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def temp_store(tmp_path, monkeypatch):
+    data_file = tmp_path / "store.json"
+    lock_file = data_file.with_suffix(".lock")
+    monkeypatch.setattr(store, "DATA_FILE", data_file, raising=False)
+    monkeypatch.setattr(store, "LOCK_FILE", lock_file, raising=False)
+    monkeypatch.setattr(store, "lock", FileLock(str(lock_file)), raising=False)
+    yield
+    if lock_file.exists():
+        lock_file.unlink()
+    if data_file.exists():
+        data_file.unlink()
+
+
+def test_store_crud():
+    client = app.test_client()
+
+    res = client.get('/api/store')
+    assert res.status_code == 200
+    assert res.get_json() == []
+
+    res = client.post('/api/store', json={'name': 'Alice'})
+    assert res.status_code == 201
+    entry = res.get_json()
+    assert entry['id'] == 1
+    assert entry['name'] == 'Alice'
+
+    res = client.get(f"/api/store/{entry['id']}")
+    assert res.status_code == 200
+    assert res.get_json()['name'] == 'Alice'
+
+    res = client.put(f"/api/store/{entry['id']}", json={'name': 'Bob'})
+    assert res.status_code == 200
+    assert res.get_json()['name'] == 'Bob'
+
+    res = client.delete(f"/api/store/{entry['id']}")
+    assert res.status_code == 200
+    assert res.get_json() == {'status': 'deleted'}
+
+    res = client.get(f"/api/store/{entry['id']}")
+    assert res.status_code == 404


### PR DESCRIPTION
## Summary
- add simple JSON store module with file locking
- provide CRUD API endpoints for JSON data
- mark JSON datastore task as done in README
- cover new endpoints with tests

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685d3fb3e9348324bdc507a49f34c31e