### PR TITLE
Implement simple token auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Dieses Repository dient als Testumgebung für:
 - [ ] `Makefile` oder `Taskfile.yml` für lokale Automatisierung
 
 ### 🔐 Sicherheit & Access Control
-- [ ] Zugriffsbeschränkung für API-Endpunkte
+- [x] Zugriffsbeschränkung für API-Endpunkte
 - [ ] Upload-Security: Dateitypprüfung, Limitierung
 - [ ] Custom Error Pages (z. B. 404, 403)
 
@@ -81,7 +81,8 @@ Die Endpunkte sind anschließend unter `http://localhost:5000/api/*` verfügbar.
 
 ### Neue Endpunkte
 
-- `POST /api/render` – erwartet JSON `{"text": "# Titel"}` und liefert gerendetes HTML zurück
+- `POST /api/login` – gibt bei korrekter Anmeldung ein Token zurück (`{"username": "admin", "password": "secret"}`)
+- `POST /api/render` – erwartet JSON `{"text": "# Titel"}` und liefert gerendetes HTML zurück (Token benötigt)
 
 ## 🖥️ Lokale Nutzung
 

--- a/api/app.py
+++ b/api/app.py
@@ -1,17 +1,42 @@
 from flask import Flask, jsonify, request
 import markdown
+import secrets
+from functools import wraps
 
 app = Flask(__name__)
+
+# Dummy user store and token storage
+USERS = {"admin": "secret"}
+TOKENS = {}
+
+
+def login_required(f):
+    """Simple decorator to require a valid token."""
+    @wraps(f)
+    def wrapper(*args, **kwargs):
+        auth = request.headers.get("Authorization", "")
+        token = None
+        if auth.startswith("Bearer "):
+            token = auth.split(" ", 1)[1]
+        if not token:
+            token = request.args.get("token")
+        if not token or token not in TOKENS.values():
+            return jsonify({"error": "unauthorized"}), 401
+        return f(*args, **kwargs)
+
+    return wrapper
 
 @app.route('/api/ping')
 def ping():
     return jsonify({'message': 'pong'})
 
 @app.route('/api/info')
+@login_required
 def info():
     return jsonify({'project': 'Codex Playground', 'status': 'development'})
 
 @app.route('/api/render', methods=['POST'])
+@login_required
 def render_markdown():
     data = request.get_json() or {}
     text = data.get('text')
@@ -19,6 +44,19 @@ def render_markdown():
         return jsonify({'error': 'no text provided'}), 400
     html = markdown.markdown(text)
     return jsonify({'html': html})
+
+
+@app.route('/api/login', methods=['POST'])
+def login():
+    """Dummy login returning a simple token."""
+    data = request.get_json() or {}
+    user = data.get("username")
+    password = data.get("password")
+    if USERS.get(user) != password:
+        return jsonify({"error": "invalid credentials"}), 401
+    token = secrets.token_hex(16)
+    TOKENS[user] = token
+    return jsonify({"token": token})
 
 if __name__ == '__main__':
     app.run(debug=True)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,24 +1,60 @@
 from api.app import app
 
+
+def login(client, username="admin", password="secret"):
+    res = client.post(
+        "/api/login", json={"username": username, "password": password}
+    )
+    assert res.status_code == 200
+    return res.get_json()["token"]
+
 def test_ping():
     client = app.test_client()
     res = client.get('/api/ping')
     assert res.status_code == 200
     assert res.get_json() == {'message': 'pong'}
 
+
+def test_login_success():
+    client = app.test_client()
+    res = client.post('/api/login', json={'username': 'admin', 'password': 'secret'})
+    assert res.status_code == 200
+    assert 'token' in res.get_json()
+
 def test_info():
     client = app.test_client()
-    res = client.get('/api/info')
+    token = login(client)
+    res = client.get('/api/info', headers={'Authorization': f'Bearer {token}'})
     assert res.status_code == 200
     assert res.get_json() == {'project': 'Codex Playground', 'status': 'development'}
 
 def test_render_markdown():
     client = app.test_client()
-    res = client.post('/api/render', json={'text': '# Title'})
+    token = login(client)
+    res = client.post('/api/render', json={'text': '# Title'}, headers={'Authorization': f'Bearer {token}'})
     assert res.status_code == 200
     assert res.get_json() == {'html': '<h1>Title</h1>'}
 
 def test_render_markdown_no_text():
     client = app.test_client()
-    res = client.post('/api/render', json={})
+    token = login(client)
+    res = client.post('/api/render', json={}, headers={'Authorization': f'Bearer {token}'})
     assert res.status_code == 400
+
+
+def test_login_failure():
+    client = app.test_client()
+    res = client.post('/api/login', json={'username': 'admin', 'password': 'wrong'})
+    assert res.status_code == 401
+
+
+def test_access_without_token():
+    client = app.test_client()
+    res = client.get('/api/info')
+    assert res.status_code == 401
+
+
+def test_render_requires_token():
+    client = app.test_client()
+    res = client.post('/api/render', json={'text': '# Title'})
+    assert res.status_code == 401


### PR DESCRIPTION
## Summary
- add token-based login decorator
- protect info and render endpoints
- add README notes about login
- test login and protected endpoints

## Testing
- `python -m py_compile api/app.py tests/test_api.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'api')*

------
https://chatgpt.com/codex/tasks/task_e_685d3fbe1fd883249502517707229199