### PR TITLE
Add Docker and DevContainer setup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,10 @@
+{
+    "name": "Codex Playground",
+    "dockerComposeFile": "../docker-compose.yml",
+    "service": "api",
+    "workspaceFolder": "/workspace/hostlab",
+    "extensions": [
+        "ms-python.python"
+    ],
+    "forwardPorts": [5000, 8080]
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY api ./api
+EXPOSE 5000
+CMD ["python", "api/app.py"]

--- a/Dockerfile.nginx
+++ b/Dockerfile.nginx
@@ -1,0 +1,2 @@
+FROM nginx:alpine
+COPY public /usr/share/nginx/html

--- a/KANBAN.md
+++ b/KANBAN.md
@@ -2,8 +2,6 @@
 
 ## Backlog
 - Landing Page gestalten
-- DevContainer für VS Code konfigurieren
-- Docker Compose zum Starten aller Services erstellen
 - File Upload Endpoint implementieren
 
 ## In Progress
@@ -14,3 +12,5 @@
 - REST-API Grundgerüst aufgesetzt
 - README erweitert und Dokumentation verbessert
 - Markdown-Renderer Endpoint umgesetzt
+- DevContainer für VS Code konfiguriert
+- Docker Compose zum Starten aller Services erstellt

--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ Dieses Repository dient als Testumgebung für:
 - [ ] API für „Fun Facts“ oder Zitate bauen
 
 ### 🐳 Docker & DevOps
-- [ ] Dockerfile für statischen Server (Nginx)
-- [ ] Dockerfile für API mit `docker-compose.yml`
-- [ ] `.devcontainer` für VS Code Remote Development
+- [x] Dockerfile für statischen Server (Nginx)
+- [x] Dockerfile für API mit `docker-compose.yml`
+- [x] `.devcontainer` für VS Code Remote Development
 - [ ] `Makefile` oder `Taskfile.yml` für lokale Automatisierung
 
 ### 🔐 Sicherheit & Access Control
@@ -67,6 +67,15 @@ source venv/bin/activate
 pip install -r requirements.txt
 # oder: docker compose up --build
 ```
+
+### Docker Compose
+
+Statt der lokalen Installation kann die Anwendung über Docker Compose gestartet werden:
+
+```bash
+docker compose up --build
+```
+Frontend steht dann auf <http://localhost:8080>, die API auf <http://localhost:5000> bereit.
 
 ### API starten
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '3.8'
+services:
+  api:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - ./api:/app/api
+    ports:
+      - "5000:5000"
+  web:
+    build:
+      context: .
+      dockerfile: Dockerfile.nginx
+    volumes:
+      - ./public:/usr/share/nginx/html:ro
+    ports:
+      - "8080:80"

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <title>Codex Playground</title>
+</head>
+<body>
+    <h1>Willkommen im Codex Playground</h1>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create Dockerfile for Flask API
- create simple nginx Dockerfile to serve static files
- add docker-compose with API and web service
- provide a VS Code devcontainer configuration
- include a basic static index.html
- document Docker compose usage in README
- update Kanban board

## Testing
- `pytest -q` *(fails: ModuleNotFoundError - Flask not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685d3fd02e208324acde3df0d9e283ca