### PR TITLE
Add static page tests and CI script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+.PHONY: test ci
+
+test:
+pytest -v
+
+ci:
+pip install -r requirements.txt
+playwright install
+pytest -v

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Codex Playground</title>
+</head>
+<body>
+    <h1>Welcome to Codex Playground</h1>
+    <p>Static content test page.</p>
+</body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Flask>=2.3
 markdown>=3.4
+playwright>=1.43

--- a/tests/test_static.py
+++ b/tests/test_static.py
@@ -1,0 +1,15 @@
+import os
+from playwright.sync_api import sync_playwright
+
+
+def test_index_page():
+    file_path = os.path.abspath(os.path.join('public', 'index.html'))
+    assert os.path.exists(file_path), 'index.html missing'
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        page = browser.new_page()
+        page.goto(f'file://{file_path}')
+        header = page.text_content('h1')
+        assert header == 'Welcome to Codex Playground'
+        browser.close()


### PR DESCRIPTION
## Summary
- add Makefile with `test` and `ci` targets
- add `playwright` dependency
- add simple static HTML page
- add Playwright test for the static page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for flask and playwright)*

------
https://chatgpt.com/codex/tasks/task_e_685d3fd85b788324a42dfee05de35f41