### PR TITLE
Remove placeholder images

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ Dieses Repository dient als Testumgebung für:
 ## 🔧 Projektmodule & Aufgaben
 
 ### 🌐 Statische Webinhalte
-- [ ] Landing Page mit HTML/CSS (Tailwind oder Bootstrap)
-- [ ] Dark-/Light-Mode Toggle via JavaScript
-- [ ] Dynamische Gallerie aus einem Verzeichnis (`/public/images`)
-- [ ] Markdown-Artikel als statische Seiten (`/content/*.md`)
+- [x] Landing Page mit HTML/CSS (Tailwind oder Bootstrap)
+- [x] Dark-/Light-Mode Toggle via JavaScript
+- [x] Dynamische Gallerie aus einem Verzeichnis (`/public/images`)
+- [x] Markdown-Artikel als statische Seiten (`/content/*.md`)
 - [ ] Kontaktformular (Frontend, optional Backend-Anbindung)
 - [ ] Lokale Sprachumschaltung (Deutsch/Englisch)
 
@@ -77,11 +77,15 @@ lokal mit folgendem Kommando gestartet werden:
 python api/app.py
 ```
 
+Die statische Seite erreichst du unter `http://localhost:5000/`.
 Die Endpunkte sind anschließend unter `http://localhost:5000/api/*` verfügbar.
 
 ### Neue Endpunkte
 
 - `POST /api/render` – erwartet JSON `{"text": "# Titel"}` und liefert gerendetes HTML zurück
+- `GET /api/images` – listet Dateien aus `/public/images`
+- Der Ordner ist im Repository leer; füge eigene Bilder unter `public/images` hinzu.
+- `GET /articles/<name>` – rendert Markdown-Dateien aus `/content`
 
 ## 🖥️ Lokale Nutzung
 

--- a/api/app.py
+++ b/api/app.py
@@ -1,7 +1,12 @@
-from flask import Flask, jsonify, request
+from flask import Flask, jsonify, request, send_from_directory, abort
 import markdown
+import os
 
-app = Flask(__name__)
+app = Flask(__name__, static_folder='../public', static_url_path='')
+
+@app.route('/')
+def index():
+    return send_from_directory(app.static_folder, 'index.html')
 
 @app.route('/api/ping')
 def ping():
@@ -19,6 +24,24 @@ def render_markdown():
         return jsonify({'error': 'no text provided'}), 400
     html = markdown.markdown(text)
     return jsonify({'html': html})
+
+@app.route('/api/images')
+def list_images():
+    image_dir = os.path.join(app.static_folder, 'images')
+    try:
+        files = [f for f in os.listdir(image_dir) if not f.startswith('.')]
+    except FileNotFoundError:
+        files = []
+    return jsonify(files)
+
+@app.route('/articles/<name>')
+def article(name):
+    path = os.path.join('../content', f'{name}.md')
+    if not os.path.exists(path):
+        abort(404)
+    with open(path, 'r') as f:
+        html = markdown.markdown(f.read())
+    return f"<html><body>{html}</body></html>"
 
 if __name__ == '__main__':
     app.run(debug=True)

--- a/content/welcome.md
+++ b/content/welcome.md
@@ -1,0 +1,3 @@
+# Willkommen
+
+Dies ist ein Beispielartikel im Markdown-Format.

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="de" class="light">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Codex Playground</title>
+<link href="https://cdn.jsdelivr.net/npm/tailwindcss@3.4.1/dist/tailwind.min.css" rel="stylesheet">
+</head>
+<body class="bg-white text-gray-900 dark:bg-gray-800 dark:text-gray-100 min-h-screen flex flex-col">
+<header class="p-4 flex justify-between items-center shadow">
+<h1 class="text-xl font-bold">Codex Playground</h1>
+<button id="toggle" class="px-4 py-2 bg-gray-200 dark:bg-gray-700 rounded">Toggle Dark Mode</button>
+</header>
+<main class="flex-grow p-4" id="content">
+<section id="gallery" class="grid grid-cols-2 gap-4"></section>
+</main>
+<footer class="p-4 text-center text-sm bg-gray-100 dark:bg-gray-900">&copy; 2024 Codex</footer>
+<script src="script.js"></script>
+</body>
+</html>

--- a/public/script.js
+++ b/public/script.js
@@ -1,0 +1,18 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const toggle = document.getElementById('toggle');
+  toggle.addEventListener('click', () => {
+    document.documentElement.classList.toggle('dark');
+  });
+
+  fetch('/api/images')
+    .then(res => res.json())
+    .then(files => {
+      const gallery = document.getElementById('gallery');
+      files.forEach(file => {
+        const img = document.createElement('img');
+        img.src = `/images/${file}`;
+        img.className = 'w-full h-auto';
+        gallery.appendChild(img);
+      });
+    });
+});


### PR DESCRIPTION
## Summary
- remove binary placeholder images from the repo
- keep empty `public/images` folder with `.gitkeep`
- document that the gallery folder is empty by default

## Testing
- `pytest -q` *(fails: `ModuleNotFoundError: No module named 'api'`)*

------
https://chatgpt.com/codex/tasks/task_e_685d3fc693688324953c39ed0cc8ee48