### PR TITLE
Add contact form feature

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from werkzeug.utils import secure_filename
 import secrets
 from functools import wraps
-from data import store
+from data import store, contact
 
 BASE_DIR = Path(__file__).resolve().parent.parent
 UPLOAD_FOLDER = BASE_DIR / "uploads"
@@ -160,6 +160,19 @@ def create_entry():
         return jsonify({'error': 'invalid data'}), 400
     new_entry = store.add_entry(data)
     return jsonify(new_entry), 201
+
+
+@app.route('/api/contact', methods=['POST'])
+def create_contact():
+    """Receive contact form submissions."""
+    data = request.get_json() or {}
+    name = data.get('name')
+    email = data.get('email')
+    message = data.get('message')
+    if not name or not email or not message:
+        return jsonify({'error': 'invalid data'}), 400
+    contact.add_contact({'name': name, 'email': email, 'message': message})
+    return jsonify({'status': 'received'}), 201
 
 
 @app.route('/api/store/<int:entry_id>', methods=['PUT'])

--- a/data/contact.py
+++ b/data/contact.py
@@ -1,0 +1,39 @@
+import json
+from pathlib import Path
+from typing import Dict, List
+from filelock import FileLock
+
+DATA_DIR = Path(__file__).resolve().parent
+DATA_FILE = DATA_DIR / "contacts.json"
+LOCK_FILE = DATA_FILE.with_suffix(".lock")
+
+DATA_DIR.mkdir(parents=True, exist_ok=True)
+lock = FileLock(str(LOCK_FILE))
+
+
+def _load() -> List[Dict[str, str]]:
+    with lock:
+        if DATA_FILE.exists():
+            with DATA_FILE.open("r", encoding="utf-8") as f:
+                try:
+                    return json.load(f)
+                except json.JSONDecodeError:
+                    return []
+        return []
+
+
+def _save(data: List[Dict[str, str]]) -> None:
+    with lock:
+        with DATA_FILE.open("w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2)
+
+
+def add_contact(entry: Dict[str, str]) -> Dict[str, str]:
+    data = _load()
+    data.append(entry)
+    _save(data)
+    return entry
+
+
+def read_all() -> List[Dict[str, str]]:
+    return _load()

--- a/public/contact.html
+++ b/public/contact.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="de" class="light">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Kontakt - Codex Playground</title>
+<link href="https://cdn.jsdelivr.net/npm/tailwindcss@3.4.1/dist/tailwind.min.css" rel="stylesheet">
+</head>
+<body class="bg-white text-gray-900 dark:bg-gray-800 dark:text-gray-100 min-h-screen flex flex-col">
+<header class="p-4 flex justify-between items-center shadow">
+<h1 class="text-xl font-bold">Kontakt</h1>
+<a href="index.html" class="text-blue-500">Home</a>
+</header>
+<main class="flex-grow p-4">
+<form id="contact-form" class="space-y-4 max-w-md">
+<input id="name" type="text" required placeholder="Name" class="w-full p-2 border rounded" />
+<input id="email" type="email" required placeholder="Email" class="w-full p-2 border rounded" />
+<textarea id="message" required placeholder="Nachricht" class="w-full p-2 border rounded"></textarea>
+<button type="submit" class="px-4 py-2 bg-blue-500 text-white rounded">Senden</button>
+</form>
+<p id="status" class="mt-4"></p>
+</main>
+<script>
+document.getElementById('contact-form').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const data = {
+    name: document.getElementById('name').value,
+    email: document.getElementById('email').value,
+    message: document.getElementById('message').value
+  };
+  const res = await fetch('/api/contact', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data)
+  });
+  const status = document.getElementById('status');
+  if (res.ok) {
+    status.textContent = 'Danke für deine Nachricht!';
+    e.target.reset();
+  } else {
+    status.textContent = 'Fehler beim Senden.';
+  }
+});
+</script>
+</body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -9,7 +9,10 @@
 <body class="bg-white text-gray-900 dark:bg-gray-800 dark:text-gray-100 min-h-screen flex flex-col">
 <header class="p-4 flex justify-between items-center shadow">
 <h1 class="text-xl font-bold">Codex Playground</h1>
-<button id="toggle" class="px-4 py-2 bg-gray-200 dark:bg-gray-700 rounded">Toggle Dark Mode</button>
+<nav class="space-x-4">
+  <a href="contact.html" class="text-blue-500">Kontakt</a>
+  <button id="toggle" class="px-4 py-2 bg-gray-200 dark:bg-gray-700 rounded">Toggle Dark Mode</button>
+</nav>
 </header>
 <main class="flex-grow p-4" id="content">
 <section id="gallery" class="grid grid-cols-2 gap-4"></section>

--- a/tests/test_contact_api.py
+++ b/tests/test_contact_api.py
@@ -1,0 +1,34 @@
+import json
+from api.app import app
+from data import contact
+from filelock import FileLock
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def temp_contact(tmp_path, monkeypatch):
+    data_file = tmp_path / "contacts.json"
+    lock_file = data_file.with_suffix(".lock")
+    monkeypatch.setattr(contact, "DATA_FILE", data_file, raising=False)
+    monkeypatch.setattr(contact, "LOCK_FILE", lock_file, raising=False)
+    monkeypatch.setattr(contact, "lock", FileLock(str(lock_file)), raising=False)
+    yield
+    if lock_file.exists():
+        lock_file.unlink()
+    if data_file.exists():
+        data_file.unlink()
+
+
+def test_create_contact():
+    client = app.test_client()
+    payload = {"name": "Alice", "email": "alice@example.com", "message": "Hi"}
+    res = client.post("/api/contact", json=payload)
+    assert res.status_code == 201
+    assert res.get_json() == {"status": "received"}
+    assert contact.read_all() == [payload]
+
+
+def test_contact_invalid():
+    client = app.test_client()
+    res = client.post("/api/contact", json={"name": "Bob"})
+    assert res.status_code == 400


### PR DESCRIPTION
## Summary
- implement simple contact data store
- create `/api/contact` endpoint to save submissions
- add contact.html static page with form
- link contact page from index.html
- add tests for new contact endpoint

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685f287b2dac8324ab11cb39a156ed8f