### PR TITLE
Fix Flask initialization

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -34,7 +34,6 @@ DEFAULT_BOARD = [
     ["R","N","B","Q","K","B","N","R"]
 ]
 
-app = Flask(__name__)
 app.config["UPLOAD_FOLDER"] = str(UPLOAD_FOLDER)
 app.config["MAX_CONTENT_LENGTH"] = 1 * 1024 * 1024  # 1MB
 


### PR DESCRIPTION
## Summary
- remove second `Flask` instance
- keep `UPLOAD_FOLDER` and `MAX_CONTENT_LENGTH` on the existing app

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6883427913488324b628028c08730cf3