### PR TITLE
Add TradingPipeline module with tests

### DIFF
--- a/pipeline/__init__.py
+++ b/pipeline/__init__.py
@@ -1,0 +1,3 @@
+from .trading_pipeline import TradingPipeline, load_pipeline
+
+__all__ = ["TradingPipeline", "load_pipeline"]

--- a/pipeline/trading_pipeline.py
+++ b/pipeline/trading_pipeline.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict
+
+
+class TradingPipeline:
+    """Simple pipeline utility for saving run artifacts."""
+
+    RUNS_ROOT = Path("runs")
+
+    def __init__(self, config: Dict[str, Any], run_name: str, run_dir: Path | None = None):
+        self.config = config
+        self.run_name = run_name
+        self.run_dir = Path(run_dir) if run_dir else None
+
+    def _write_config(self) -> None:
+        config_file = self.run_dir / "config.yml"
+        with config_file.open("w", encoding="utf-8") as f:
+            for key, value in self.config.items():
+                f.write(f"{key}: {value}\n")
+
+    def _prepare_run_dir(self) -> None:
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        self.RUNS_ROOT.mkdir(exist_ok=True)
+        self.run_dir = self.RUNS_ROOT / f"{timestamp}_{self.run_name}"
+        self.run_dir.mkdir(parents=True, exist_ok=True)
+        self._write_config()
+        (self.run_dir / "tensorboard").mkdir(exist_ok=True)
+        (self.run_dir / "model.ckpt").write_text("placeholder", encoding="utf-8")
+        (self.run_dir / "metrics.json").write_text("{}", encoding="utf-8")
+
+    def run(self, resume: bool = False) -> Path:
+        if not resume or self.run_dir is None:
+            self._prepare_run_dir()
+        latest = self.RUNS_ROOT / "latest.txt"
+        latest.write_text(str(self.run_dir), encoding="utf-8")
+        return self.run_dir
+
+    @classmethod
+    def load(cls, run_dir: str | Path) -> "TradingPipeline":
+        run_dir_path = Path(run_dir)
+        config = {}
+        config_path = run_dir_path / "config.yml"
+        if config_path.exists():
+            with config_path.open("r", encoding="utf-8") as f:
+                for line in f:
+                    if ":" in line:
+                        key, value = line.split(":", 1)
+                        config[key.strip()] = value.strip()
+        run_name = run_dir_path.name.split("_", 2)[-1]
+        return cls(config, run_name, run_dir=run_dir_path)
+
+def load_pipeline(run_dir: str | Path) -> TradingPipeline:
+    return TradingPipeline.load(run_dir)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+from pipeline import TradingPipeline, load_pipeline
+
+
+def test_run_and_load(tmp_path, monkeypatch):
+    runs_root = tmp_path / "runs"
+    monkeypatch.setattr(TradingPipeline, "RUNS_ROOT", runs_root)
+    cfg = {"lr": 0.1, "epochs": 1}
+    pipe = TradingPipeline(cfg, "demo")
+    run_dir = pipe.run()
+
+    # files created
+    assert (run_dir / "config.yml").exists()
+    assert (run_dir / "metrics.json").exists()
+    assert (run_dir / "tensorboard").is_dir()
+    assert (run_dir / "model.ckpt").exists()
+    latest = runs_root / "latest.txt"
+    assert latest.read_text() == str(run_dir)
+
+    # load and resume
+    loaded = load_pipeline(run_dir)
+    monkeypatch.setattr(loaded, "RUNS_ROOT", runs_root)
+    resumed_dir = loaded.run(resume=True)
+    assert resumed_dir == run_dir
+    assert latest.read_text() == str(run_dir)


### PR DESCRIPTION
## Summary
- add `pipeline` package with `TradingPipeline` class
- save configs and artifacts when running the pipeline
- allow loading and resuming existing runs
- expose convenience imports in `pipeline/__init__.py`
- test pipeline creation and resume logic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6883427acd60832485d125a466c55084