### PR TITLE
Add TradingPipeline and tests

### DIFF
--- a/tests/test_trading_pipeline.py
+++ b/tests/test_trading_pipeline.py
@@ -1,0 +1,27 @@
+import os
+import sys
+from pathlib import Path
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from trading.pipeline import TradingPipeline
+
+
+def test_trading_pipeline_run_and_resume(tmp_path):
+    runs_dir = tmp_path / "runs"
+    config = {"param": 1}
+    pipeline = TradingPipeline(config, name="demo", runs_dir=runs_dir)
+
+    run_path = pipeline.run()
+    assert run_path.exists()
+    assert (run_path / "config.yml").is_file()
+
+    latest_file = runs_dir / "latest.txt"
+    assert latest_file.is_file()
+    assert latest_file.read_text() == str(run_path)
+
+    loaded = TradingPipeline.load(run_path)
+    loaded.run(resume=True)
+
+    # ensure no new directory created
+    subdirs = [p for p in (runs_dir / "demo").iterdir() if p.is_dir()]
+    assert len(subdirs) == 1
+    assert subdirs[0] == run_path

--- a/trading/pipeline.py
+++ b/trading/pipeline.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+from pathlib import Path
+from datetime import datetime
+import json
+
+
+class TradingPipeline:
+    def __init__(self, config: dict, name: str, runs_dir: str | Path = "runs"):
+        self.config = config
+        self.name = name
+        self.runs_dir = Path(runs_dir)
+        self.run_path: Path | None = None
+
+    def run(self, resume: bool = False) -> Path:
+        if resume:
+            if self.run_path is None:
+                raise ValueError("No run_path set for resume")
+            # Do not create new directories when resuming
+            return self.run_path
+
+        root = self.runs_dir / self.name
+        root.mkdir(parents=True, exist_ok=True)
+        run_id = datetime.now().strftime("%Y%m%d%H%M%S")
+        self.run_path = root / run_id
+        self.run_path.mkdir(parents=True, exist_ok=True)
+
+        # Save config
+        config_file = self.run_path / "config.yml"
+        with open(config_file, "w") as f:
+            json.dump(self.config, f)
+
+        # Update latest pointer
+        latest_file = self.runs_dir / "latest.txt"
+        latest_file.write_text(str(self.run_path))
+
+        return self.run_path
+
+    @classmethod
+    def load(cls, run_path: str | Path) -> "TradingPipeline":
+        run_path = Path(run_path)
+        config_file = run_path / "config.yml"
+        with open(config_file) as f:
+            config = json.load(f)
+        name = run_path.parent.name
+        runs_dir = run_path.parents[1]
+        pipeline = cls(config=config, name=name, runs_dir=runs_dir)
+        pipeline.run_path = run_path
+        return pipeline


### PR DESCRIPTION
## Summary
- implement a simple `TradingPipeline` to manage run directories
- add tests for the new trading pipeline

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6883427d1af08324b0433b4e17da7792